### PR TITLE
Send parent pid to nsm

### DIFF
--- a/sources/common.cc
+++ b/sources/common.cc
@@ -587,7 +587,7 @@ void handle_signals()
     int nsignal = 0;
 
     sigemptyset(&sigs);
-    for (int signo : {SIGINT, SIGTERM}) {
+    for (int signo : {SIGINT, SIGTERM, SIGHUP}) {
         sigaddset(&sigs, signo);
         nsignal = signo + 1;
     }

--- a/thirdparty/nonlib/nsm.h
+++ b/thirdparty/nonlib/nsm.h
@@ -240,7 +240,8 @@ nsm_send_announce ( nsm_client_t *nsm, const char *app_name, const char *capabil
         return;
     }
 
-    int pid = (int)getpid();
+    // int pid = (int)getpid();
+    int pid = (int)getppid();
 
     lo_send_from( to, _NSM()->_server, LO_TT_IMMEDIATE, "/nsm/server/announce", "sssiii",
                   app_name,


### PR DESCRIPTION
This a way to match the pid send from adljack to that of the process started by the NSM daemon. 

It sends the parent pid (the pid of the terminal adljack is launched in) and let's adljack exite by catching SIGHUP when the terminal application gets SIGTERM from the NSM daemon. 

Adljack still works this way in NSM. You might want to test it yourself to first. 

See: https://github.com/jpcima/adljack/issues/28